### PR TITLE
Remove .cargo and .vscode and ignore them

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-[build]
-# Redirect the Cargo target directory to a path without spaces.
-# This is required because windres (GNU toolchain) cannot handle spaces in paths.
-target-dir = "F:/kb-emu-target"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ android-sdk/
 .gemini/
 .agents/
 
+.vscode
+.cargo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["tauri-apps.tauri-vscode", "rust-lang.rust-analyzer"]
-}


### PR DESCRIPTION
This PR removes the unnecessary .cargo and .vscode configuration folders from the repository and adds them to .gitignore to ensure they dont interrupt the Github Actions/Workflow.

